### PR TITLE
[MEMO1.0-002] テーマ画面のタイトルを「テーマ」に修正しました

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".ui.theme.ThemeActivity"
-            android:label="テーマ" />
+            android:label="@string/theme" />
         <activity android:name=".ui.aboutapp.AboutAppActivity" />
         <activity
             android:name=".ui.search.SearchActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,9 @@
         <activity
             android:name=".ui.edit.EditActivity"
             android:windowSoftInputMode="adjustResize" />
-        <activity android:name=".ui.theme.ThemeActivity" />
+        <activity
+            android:name=".ui.theme.ThemeActivity"
+            android:label="テーマ" />
         <activity android:name=".ui.aboutapp.AboutAppActivity" />
         <activity
             android:name=".ui.search.SearchActivity"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,11 +15,11 @@
     <color name="colorStatusBar1">#DC8D7B</color>// 220 141 123
     <color name="colorStatusBar2">#DE8EB3</color>// 222 142 179
     <color name="colorStatusBar3">#C79CE8</color>// 199 156 232
-    <color name="colorStatusBar4">#304FC1</color>// 48 79 193
+    <color name="colorStatusBar4">#E4A469</color>// 48 79 193
     <color name="colorStatusBar5">#92AAD6</color>// 146 170 214
     <color name="colorStatusBar6">#81AAA7</color>// 129 170 167
     <color name="colorStatusBar7">#6EA369</color>// 110 163 105
-    <color name="colorStatusBar8">#E4A469</color>// 228 164 105
+    <color name="colorStatusBar8">#304FC1</color>// 228 164 105
 
     <!-- HeaderBar Color -->
     <color name="colorHeaderBar1">#E9B6AA</color>// 233 182 170

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,11 +15,11 @@
     <color name="colorStatusBar1">#DC8D7B</color>// 220 141 123
     <color name="colorStatusBar2">#DE8EB3</color>// 222 142 179
     <color name="colorStatusBar3">#C79CE8</color>// 199 156 232
-    <color name="colorStatusBar4">#E4A469</color>// 48 79 193
+    <color name="colorStatusBar4">#304FC1</color>// 48 79 193
     <color name="colorStatusBar5">#92AAD6</color>// 146 170 214
     <color name="colorStatusBar6">#81AAA7</color>// 129 170 167
     <color name="colorStatusBar7">#6EA369</color>// 110 163 105
-    <color name="colorStatusBar8">#304FC1</color>// 228 164 105
+    <color name="colorStatusBar8">#E4A469</color>// 228 164 105
 
     <!-- HeaderBar Color -->
     <color name="colorHeaderBar1">#E9B6AA</color>// 233 182 170


### PR DESCRIPTION
## 問題の原因
- AndroidManifest.xml内のThemeActivityにおいて、labelが記述されていませんでした。
## 対応内容
- 上記箇所に「android:label="@string/theme"」を追記しました。
## fixed file
- AndroidManifest.xml
## コミット前の動作確認
- テーマ画面のタイトルを確認しました。
1. アプリを起動
1. 設定画面へ遷移
1. 「テーマ」を選択し、テーマ選択画面へ遷移
1. ツールバーのタイトルが「テーマ」と表示されている