### PR TITLE
[MEMO1.0-006] アプリ名を「メーモ」に修正しました

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">メモ帳</string>
+    <string name="app_name">メーモ</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
 


### PR DESCRIPTION
## 問題の原因
- AndroidManifest.xml内のThemeActivityにおいて、labelが記述されていませんでした。
## 対応内容
- res/values/strings.xmlのapp_nameの値を「メーモ」に修正しました。
## fixed file
- res/values/strings.xml
## コミット前の動作確認
- アプリ名を確認しました。
1. アプリのランチャーアイコン下の表示が「メーモ」になっている。