### PR TITLE
[MEMO1.0-007] メモが空の場合の表示を修正しました

### DIFF
--- a/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
@@ -225,7 +225,7 @@ public class MainFragment extends BaseFragment implements MainContract.MainView 
         recyclerView.setVisibility(View.GONE);
         emptyText.setVisibility(View.VISIBLE);
         if (MyApplication.selectNavigationItem != Constant.NavigationItem.DELETE) {
-            emptyText.setText("空です");
+            emptyText.setText("メモがありません。");
         }
     }
 

--- a/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
@@ -225,7 +225,7 @@ public class MainFragment extends BaseFragment implements MainContract.MainView 
         recyclerView.setVisibility(View.GONE);
         emptyText.setVisibility(View.VISIBLE);
         if (MyApplication.selectNavigationItem != Constant.NavigationItem.DELETE) {
-            emptyText.setText("メモがありません。");
+            emptyText.setText(R.string.not_memo);
         } else {
             emptyText.setText("空です");
         }

--- a/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
@@ -226,6 +226,8 @@ public class MainFragment extends BaseFragment implements MainContract.MainView 
         emptyText.setVisibility(View.VISIBLE);
         if (MyApplication.selectNavigationItem != Constant.NavigationItem.DELETE) {
             emptyText.setText("メモがありません。");
+        } else {
+            emptyText.setText("空です");
         }
     }
 


### PR DESCRIPTION
## 問題の原因
- MainFragment.java内のshowEmptyメソッドにおいて、メモが空の場合、どの画面でも「空です」が表示されるようになっていました。
## 対応内容
- 上記箇所において、メモが空の場合、すべてのメモ画面およびお気に入り画面では「メモがありません。」、ゴミ箱画面では「空です」が表示されるよう修正しました。
## fixed file
- MainFragment.java
## コミット前の動作確認
- メモが空の場合のメッセージを確認しました。
1. アプリを起動
1. メモが空の場合、すべてのメモ画面およびお気に入り画面では「メモがありません。」、ゴミ箱画面では「空です」と表示される。