### PR TITLE
[MEMO1.0-008] ゴミ箱が空の場合の表示を修正しました

### DIFF
--- a/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
@@ -225,7 +225,9 @@ public class MainFragment extends BaseFragment implements MainContract.MainView 
         recyclerView.setVisibility(View.GONE);
         emptyText.setVisibility(View.VISIBLE);
         if (MyApplication.selectNavigationItem != Constant.NavigationItem.DELETE) {
-            emptyText.setText("空です");
+            emptyText.setText("メモがありません。");
+        } else {
+            emptyText.setText("ゴミ箱にメモがありません。");
         }
     }
 

--- a/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
@@ -225,9 +225,9 @@ public class MainFragment extends BaseFragment implements MainContract.MainView 
         recyclerView.setVisibility(View.GONE);
         emptyText.setVisibility(View.VISIBLE);
         if (MyApplication.selectNavigationItem != Constant.NavigationItem.DELETE) {
-            emptyText.setText("メモがありません。");
+            emptyText.setText("空です");
         } else {
-            emptyText.setText("ゴミ箱にメモがありません。");
+            emptyText.setText(R.string.not_delete_memo);
         }
     }
 


### PR DESCRIPTION
## 問題の原因
- MainFragment.java内のshowEmptyメソッドにおいて、メモが空の場合、どの画面でも「空です」が表示されるようになっていました。
## 対応内容
- 上記箇所において、メモが空の場合、すべてのメモ画面およびお気に入り画面では「メモがありません。」、ゴミ箱画面では「ゴミ箱にメモがありません。」が表示されるよう修正しました。
## fixed file
- MainFragment.java
## コミット前の動作確認
- メモが空の場合のメッセージを確認しました。
1. アプリを起動
1. メモが空の場合、すべてのメモ画面およびお気に入り画面では「メモがありません。」、ゴミ箱画面では「ゴミ箱にメモがありません。」と表示される。