### PR TITLE
[MEMO1.0-010] バージョン番号を修正しました

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     // app versioning
-    def versionMajor = 0
+    def versionMajor = 1
     def versionMinor = 0
     def versionPatch = 0
     def versionBuild = 0


### PR DESCRIPTION
## 問題の原因
- build.gradle (Module: app) において、versionMajorの値が0になっていました。
## 対応内容
- 上記箇所において、値を1に修正しました。
## fixed file
- build.gradle (Module: app) 
## コミット前の動作確認
- バージョン番号が正しいことを確認しました。
1. アプリを起動する。
1. 設定画面に遷移し「このアプリについて」を選択。
1. バージョン欄の下に表示されている番号が「1.0.0」になっている。
