### PR TITLE
[MEMO1.0-011] 文字サイズ「小」の設定を修正しました

### DIFF
--- a/app/src/main/java/com/example/e01_memo/util/SharedPreferencesUtil.java
+++ b/app/src/main/java/com/example/e01_memo/util/SharedPreferencesUtil.java
@@ -34,7 +34,7 @@ public class SharedPreferencesUtil {
     }
 
     public enum MojiSizeSetting {
-        MojiSmall(R.string.small, 14), MojiDefault(R.string.defaultStr, 16), MojiBig(R.string.big, 20);
+        MojiSmall(R.string.small, 12), MojiDefault(R.string.defaultStr, 16), MojiBig(R.string.big, 20);
         int mojiSize;
         int mojiNameResId;
         MojiSizeSetting(int nameResId, int size) {

--- a/app/src/main/java/com/example/e01_memo/util/SharedPreferencesUtil.java
+++ b/app/src/main/java/com/example/e01_memo/util/SharedPreferencesUtil.java
@@ -34,7 +34,7 @@ public class SharedPreferencesUtil {
     }
 
     public enum MojiSizeSetting {
-        MojiSmall(R.string.small, 8), MojiDefault(R.string.defaultStr, 16), MojiBig(R.string.big, 20);
+        MojiSmall(R.string.small, 14), MojiDefault(R.string.defaultStr, 16), MojiBig(R.string.big, 20);
         int mojiSize;
         int mojiNameResId;
         MojiSizeSetting(int nameResId, int size) {


### PR DESCRIPTION
## 問題の原因
- util/SharedPreferencesUtil.java内のMojiSizeSettingにおいて、文字サイズ「小」のサイズが8ptになっていました。
## 対応内容
- 上記箇所において、文字サイズ「小」のサイズを12ptに修正しました。
## fixed file
- util/SharedPreferencesUtil.java
## コミット前の動作確認
- 文字サイズが「小」の場合の文字サイズが12ptであることを確認しました。
1. 設定画面に遷移。
1. 文字サイズから「小」を選択。
1. メモ編集画面に遷移。
1. 入力文字のサイズが12ptであることを確認。