### PR TITLE
[fix_else_statement_duplication] else文の重複を解消しました

### DIFF
--- a/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
@@ -227,8 +227,6 @@ public class MainFragment extends BaseFragment implements MainContract.MainView 
         if (MyApplication.selectNavigationItem != Constant.NavigationItem.DELETE) {
             emptyText.setText(R.string.not_memo);
         } else {
-            emptyText.setText("空です");
-        } else {
             emptyText.setText(R.string.not_delete_memo);
         }
     }


### PR DESCRIPTION
## 問題の原因
- mainFragment.javaにおいて、else文が重複していました。
- MEMO1.0-007とMEMO1.0-008に関する変更内容がコンフリクトしていました。
## 対応内容
- 上記箇所において、不要なelse文を削除しました。
## fixed file
- mainFragment.java
## コミット前の動作確認
- MEMO1.0-007とMEMO1.0-008に関する変更が正しく反映されていることを確認しました。
1. アプリを起動
1. メモが空の場合、すべてのメモ画面およびお気に入り画面では「メモがありません。」、ゴミ箱画面では「ゴミ箱にメモがありません。」と表示される。