### PR TITLE
[MEMO1.0-011] 設定画面の選択項目にRipple Effectを実装しました

### DIFF
--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -39,7 +39,8 @@
             android:layout_width="match_parent"
             android:layout_height="72dp"
             android:orientation="vertical"
-            android:gravity="center_vertical">
+            android:gravity="center_vertical"
+            android:background="?android:attr/selectableItemBackground">
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -54,8 +55,7 @@
                     android:textSize="16sp"
                     android:textStyle="bold"
                     android:text="@string/mojiSize"
-                    android:textColor="@android:color/black"
-                    android:background="?android:attr/selectableItemBackground"/>
+                    android:textColor="@android:color/black" />
 
                 <TextView
                     android:id="@+id/mojiSizeText"

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -31,7 +31,8 @@
             android:textColor="@android:color/black"
             android:textSize="16sp"
             android:paddingStart="72dp"
-            android:gravity="center_vertical" />
+            android:gravity="center_vertical"
+            android:background="?android:attr/selectableItemBackground"/>
 
         <LinearLayout
             android:id="@+id/mojiSize"
@@ -53,7 +54,8 @@
                     android:textSize="16sp"
                     android:textStyle="bold"
                     android:text="@string/mojiSize"
-                    android:textColor="@android:color/black"/>
+                    android:textColor="@android:color/black"
+                    android:background="?android:attr/selectableItemBackground"/>
 
                 <TextView
                     android:id="@+id/mojiSizeText"
@@ -93,7 +95,8 @@
             android:textColor="@android:color/black"
             android:textSize="16sp"
             android:paddingStart="72dp"
-            android:gravity="center_vertical" />
+            android:gravity="center_vertical"
+            android:background="?android:attr/selectableItemBackground"/>
 
         <TextView
             android:id="@+id/aboutApp"
@@ -104,7 +107,8 @@
             android:textColor="@android:color/black"
             android:textSize="16sp"
             android:paddingStart="72dp"
-            android:gravity="center_vertical" />
+            android:gravity="center_vertical"
+            android:background="?android:attr/selectableItemBackground"/>
 
     </LinearLayout>
 


### PR DESCRIPTION
## 問題の原因
- fragment_setting.xmlにおいて、「android:background="?android:attr/selectableItemBackground"」が記述されていませんでした。
## 対応内容
- 上記において、「フォント」「文字サイズ」「テーマ」「このアプリについて」のそれぞれに「android:background="?android:attr/selectableItemBackground"」を追記しました。
## fixed file
- fragment_setting.xml
## コミット前の動作確認
- 設定画面の選択項目にRipple Effectが実装されていることを確認しました。
1. 設定画面に遷移。
1. 「フォント」「文字サイズ」「テーマ」「このアプリについて」をそれぞれ選択。
1. Ripple Effectが現れることを確認。