### PR TITLE
[MEMO1.0-009] メモ編集画面でキーボードを表示してもバーが隠れてしまわないよう修正しました

### DIFF
--- a/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
@@ -128,11 +128,7 @@ public class EditFragment extends BaseFragment implements EditContract.EditView,
 
     @Override
     public void onResume() {
-        if (selectId == -1)  {
-            showSoftKeyboard();
-        } else {
-            getActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-        }
+        showSoftKeyboard();
         super.onResume();
     }
 


### PR DESCRIPTION
## 問題の原因
- EditFragment.javaにおいて、ソフトウェアキーボードの表示方法が新規メモと既存メモで異なっていました。
## 対応内容
- 上記において、ソフトウェアキーボードの表示方法を新規メモ、既存メモともにshowSoftKeyboardメソッドで行うように変更しました。
- これに伴いif-else文が不要になったため、if-else文を削除しました。
## fixed file
- EditFragment.java
## コミット前の動作確認
- キーボードが表示されるとそのキーボードの上にバーが表示されることを確認しました。
1. 既存のメモファイルを選択
1. キーボードが表示されるとそのキーボードの上にバーが表示されることを確認