### PR TITLE
[MEMO1.0-004] 新規メモ作成画面からバックボタンを押しても強制終了しないようにしました

### DIFF
--- a/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
@@ -155,7 +155,9 @@ public class EditFragment extends BaseFragment implements EditContract.EditView,
 
     @Override
     public void hideSoftKeyboard() {
-        inputMethodManager.hideSoftInputFromWindow(getActivity().getWindow().getCurrentFocus().getWindowToken(), 0);
+        if (getActivity().getWindow().getCurrentFocus() != null) {
+            inputMethodManager.hideSoftInputFromWindow(getActivity().getWindow().getCurrentFocus().getWindowToken(), 0);
+        }
     }
 
     @Override


### PR DESCRIPTION
## 問題の原因
- EditFragment.javaにおいて、フォーカスがない場合にgetCurrentFocus()メソッドがnullを返していたため、異常終了していました。
## 対応内容
- 上記において、getCurrentFocus()メソッドがnullを返さない場合のみ、hideSoftInputFromWindow()メソッドを呼び出すよう修正しました。
## fixed file
- EditFragment.java
## コミット前の動作確認
- 新規メモ作成画面からバックボタンを押しても強制終了しないことを確認しました。
1. アプリを起動。
1. 画面右下のボタンをタップし、新規メモ作成画面に遷移する。
1. バックボタンをタップして前の画面に戻る。
1. アプリが強制終了しないことを確認。