### PR TITLE
[MEMO1.0-005] 新規メモ画面でキーボードが表示された後、メモに文字を入力できるように修正しました。

### DIFF
--- a/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
@@ -129,6 +129,7 @@ public class EditFragment extends BaseFragment implements EditContract.EditView,
     @Override
     public void onResume() {
         if (selectId == -1)  {
+            editText.requestFocus();
             showSoftKeyboard();
         } else {
             getActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);


### PR DESCRIPTION
## 問題の原因
- EditFragment.javaのonResumeメソッドにおいて、新規メモ画面表示時にフォーカスがありませんでした。
## 対応内容
- 上記において、新規メモ画面表示時にrequestFocusメソッドを呼び出すよう修正しました。
## fixed file
- EditFragment.java
## コミット前の動作確認
- 新規メモ画面でキーボードが表示された後、メモに文字が入力できることを確認しました。
1. アプリを起動。
1. 右下のボタンから新規メモ画面へ遷移。
1. キーボードが自動で表示され、タップするとメモに文字が入力できることを確認。